### PR TITLE
fix: make sure rank metric is reset after each epoch

### DIFF
--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -132,6 +132,7 @@ func (w *Watcher) collectValidators(ctx context.Context) (near.ValidatorsRespons
 	w.metrics.ValidatorProducedChunks.Reset()
 	w.metrics.ValidatorSlashed.Reset()
 	w.metrics.ValidatorStake.Reset()
+	w.metrics.ValidatorRank.Reset()
 	w.metrics.NextValidatorStake.Reset()
 	w.metrics.CurrentProposals.Reset()
 	w.metrics.PrevEpochKickout.Reset()


### PR DESCRIPTION
to avoid exploding metrics cardinality